### PR TITLE
Feat/prevent unathorized or unauthenticed tickets access

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -3,6 +3,7 @@
 class TicketsController < ApplicationController
   before_action :set_project
   before_action :set_ticket, only: %i[show edit update destroy watch]
+  before_action :authenticate_user!
 
   def new
     @ticket = @project.tickets.build

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -35,6 +35,12 @@ class TicketsController < ApplicationController
   def edit; end
 
   def update
+    unless @ticket.author == current_user || @current_user.admin?
+      flash[:alert] = 'Only ticket authors or admins can edit tickets'
+      redirect_to [@project, @ticket]
+      return
+    end
+
     if @ticket.update(ticket_params)
       @ticket.tags << processed_tags
       flash[:notice] = 'Ticket has been updated.'
@@ -44,6 +50,7 @@ class TicketsController < ApplicationController
       render 'edit'
     end
   end
+  
 
   def destroy
     return unless @ticket.delete

--- a/app/helpers/tickets_helper.rb
+++ b/app/helpers/tickets_helper.rb
@@ -10,4 +10,10 @@ module TicketsHelper
     link_to text, watch_project_ticket_path(ticket.project, ticket),
             class: text.parameterize, method: :patch
   end
+
+  def authors_or_admins_only(ticket, &block)
+    return unless current_user == ticket.author || current_user.admin?
+
+    block.call
+  end
 end

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -6,11 +6,13 @@
   <header>
     <h2><%= @ticket.name %></h2>
 
-    <ul class="actions">
-      <li><%= link_to 'Edit Ticket', [:edit, @project, @ticket] %></li>
-      <li><%= link_to 'Delete Ticket', [@project, @ticket], method: :delete,
-        data: { confirm: 'Are you sure you want to delete this ticket?'} %></li>
-    </ul>
+    <% authors_or_admins_only(@ticket) do %>
+      <ul class="actions">
+        <li><%= link_to 'Edit Ticket', [:edit, @project, @ticket] %></li>
+        <li><%= link_to 'Delete Ticket', [@project, @ticket], method: :delete,
+              data: { confirm: 'Are you sure you want to delete this ticket?'} %></li>
+      </ul>
+    <% end %>
   </header>
 
   <table class="attributes">

--- a/spec/features/deleting_tickets_spec.rb
+++ b/spec/features/deleting_tickets_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.feature 'Users can delete tickets' do
   let(:project) { FactoryBot.create(:project) }
-  let(:ticket) { FactoryBot.create(:ticket, project: project ) }
   let(:bob) { FactoryBot.create(:user, email: 'bob@example.com') }
+  let(:alice) { FactoryBot.create(:user, email: 'alice@example.com') }
+  let(:ticket) { FactoryBot.create(:ticket, project: project, author: bob ) }
 
   before do
     login_as(bob)
@@ -16,5 +17,11 @@ RSpec.feature 'Users can delete tickets' do
     expect(page).to have_content 'Ticket has been deleted.'
     expect(page.current_url).to eq project_url(project)
     expect(page).to_not have_content(ticket.name)
+  end
+
+  scenario "except when they don't own the ticket or they aren't admins" do
+    login_as(alice)
+    page.reset!
+    expect(page).to_not have_link 'Delete Ticket'
   end
 end

--- a/spec/features/deleting_tickets_spec.rb
+++ b/spec/features/deleting_tickets_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.feature 'Users can delete tickets' do
   let(:project) { FactoryBot.create(:project) }
   let(:ticket) { FactoryBot.create(:ticket, project: project ) }
+  let(:bob) { FactoryBot.create(:user, email: 'bob@example.com') }
 
   before do
+    login_as(bob)
     visit project_ticket_path(project, ticket)
   end
 

--- a/spec/features/editing_ticket_spec.rb
+++ b/spec/features/editing_ticket_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.feature 'Users can update tickets' do
   let(:project) { FactoryBot.create(:project) }
-  let(:ticket) { FactoryBot.create(:ticket, project: project) }
   let(:bob) { FactoryBot.create(:user, email: 'bob@example.com') }
+  let(:alice) { FactoryBot.create(:user, email: 'alice@example.com') }
+  let(:admin) { FactoryBot.create(:user, :admin) }
+  let(:ticket) { FactoryBot.create(:ticket, project: project, author: bob) }
 
   before do
     login_as(bob)
@@ -57,6 +59,27 @@ RSpec.feature 'Users can update tickets' do
         expect(page).to have_content('Regression')
         expect(page).to have_content('Bug')
       end
+    end
+  end
+
+  context 'if they own it or are admins' do
+    it 'shows error message if they aren\'t the authors or admin' do
+      login_as(alice)
+      click_link 'Edit Ticket'
+      fill_in 'Name', with: 'Make it really shiny!'
+      click_button 'Update Ticket'
+
+      expect(page).to have_content 'Only ticket authors or admins can edit tickets'
+    end
+
+    it 'is successful if they are admins' do
+      login_as(admin)
+
+      click_link 'Edit Ticket'
+      fill_in 'Name', with: 'Make it really shiny!'
+      click_button 'Update Ticket'
+
+      expect(page).to have_content 'Ticket has been updated.'
     end
   end
 end

--- a/spec/features/editing_ticket_spec.rb
+++ b/spec/features/editing_ticket_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.feature 'Users can update tickets' do
   let(:project) { FactoryBot.create(:project) }
   let(:ticket) { FactoryBot.create(:ticket, project: project) }
+  let(:bob) { FactoryBot.create(:user, email: 'bob@example.com') }
 
   before do
+    login_as(bob)
     visit project_ticket_path(project, ticket)
   end
 

--- a/spec/features/viewing_tickets_spec.rb
+++ b/spec/features/viewing_tickets_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Users can view tickets' do
+  let(:bob) { FactoryBot.create(:user, email: 'bob@example.com') }
+
   before do
     vscode = FactoryBot.create(:project, name: 'Visual Studio Code')
     FactoryBot
@@ -27,11 +29,24 @@ RSpec.feature 'Users can view tickets' do
     expect(page).to have_content 'Make it shiny!'
     expect(page).to_not have_content 'Standards Compliance'
 
+    login_as(bob)
     click_link 'Make it shiny!'
+
     within('.ticket h2') do
       expect(page).to have_content 'Make it shiny!'
     end
 
     expect(page).to have_content 'Gradients! Starbursts! Oh my!'
+  end
+
+  scenario 'redirect to sign in page if not authenticated' do
+    click_link 'Visual Studio Code'
+
+    expect(page).to have_content 'Make it shiny!'
+    expect(page).to_not have_content 'Standards Compliance'
+
+    click_link 'Make it shiny!'
+    expect(page).to have_current_path(new_user_session_path)
+    expect(page).to have_content 'You need to sign in or sign up before continuing.'
   end
 end


### PR DESCRIPTION
## What does this PR do❓ 
This PR implemented the following features 👇 

- [x] Only authenticated users can view, edit or delete tickets 
- [x] Only ticket authors and admins can edit a ticket ✏️ 
- [x] Only ticket authors and admins can delete a ticket ❌
- [x] Hide the delete and edit links from users who are neither the author of the ticket nor an admin

## Description of the tasks completed 👇 
 
- [x] Used BDD - wrote failing tests before making them pass ✔️ 
- [x]  Only authenticated or authorized users can now interact with tickets