### PR TITLE
Feat/enabled admin operations on projects

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -38,6 +38,9 @@ class Admin::ProjectsController < Admin::ApplicationController
 
     flash[:notice] = 'Project has been deleted.'
     redirect_to projects_path
+  rescue ActiveRecord::InvalidForeignKey
+    flash[:alert] = 'Project has tickets and cannot be deleted.'
+    redirect_to admin_projects_path
   end
 
   private

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -1,5 +1,9 @@
 class Admin::ProjectsController < Admin::ApplicationController
-  before_action :set_project, except: %i[new create]
+  before_action :set_project, except: %i[index new create]
+
+  def index
+    @projects = Project.all
+  end
 
   def new
     @project = Project.new

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,5 +3,5 @@
 class Project < ApplicationRecord
   validates :name, presence: true
 
-  has_many :tickets, dependent: :delete_all
+  has_many :tickets, dependent: :destroy
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -18,6 +18,10 @@ class Ticket < ApplicationRecord
   has_and_belongs_to_many :tags
 
   scope :belonging_to_project, ->(project_id) { where('project_id = ?', project_id)}
+  scope :closed, -> { where('state_id = ?', State.where('name = ?', 'Closed').first&.id).distinct.count }
+  scope :newly_created, -> { where('state_id = ?', State.where('name = ?', 'New').first&.id).distinct.count }
+
+  scope :active, -> { count - closed }
 
   private
 

--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -10,6 +10,7 @@
     <ul class="nav flex-column">
       <li><%= link_to 'Users', admin_users_path %></li>
       <li><%= link_to 'States', admin_states_path %></li>
+      <li><%= link_to 'Projects', admin_projects_path %></li>
     </ul>
   </div>
 </div>

--- a/app/views/admin/projects/_project.html.erb
+++ b/app/views/admin/projects/_project.html.erb
@@ -6,6 +6,9 @@
           <td><%= "#{project.tickets.newly_created} new" %></td>
           <td><%= "#{project.tickets.closed} closed" %></td>
           <td><%= "#{project.tickets.active} active" %></td>
+          <td><%= link_to '',
+          edit_admin_project_path(project),
+          class: "edit" %></td>
           <td><%= link_to 'X',
           admin_project_path(project),
           method: :delete,

--- a/app/views/admin/projects/_project.html.erb
+++ b/app/views/admin/projects/_project.html.erb
@@ -6,5 +6,10 @@
           <td><%= "#{project.tickets.newly_created} new" %></td>
           <td><%= "#{project.tickets.closed} closed" %></td>
           <td><%= "#{project.tickets.active} active" %></td>
+          <td><%= link_to 'X',
+          admin_project_path(project),
+          method: :delete,
+          data: { confirm: "Are you sure you want to delete this project?" },
+          class: "delete" %></td>
         </tr>
       <% end %>

--- a/app/views/admin/projects/_project.html.erb
+++ b/app/views/admin/projects/_project.html.erb
@@ -1,0 +1,10 @@
+<%= link_to project_path(project) do %>
+  <tr>
+    <td><%= project.id %>
+      <td><%= link_to project.name, [project] %>
+        <td><%= project.tickets.count %>
+          <td><%= "#{project.tickets.newly_created} new" %></td>
+          <td><%= "#{project.tickets.closed} closed" %></td>
+          <td><%= "#{project.tickets.active} active" %></td>
+        </tr>
+      <% end %>

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -1,0 +1,20 @@
+<header>
+  <h1>Projects</h1>
+</header>
+
+<table class="table table-striped table-hover projects">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">Name</th>
+      <th scope="col">Tickets</th>
+      <th scope="col">New Tickets</th>
+      <th scope="col">Closed Tickets</th>
+      <th scope="col">Active Tickets</th>
+      <th scope="col">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render @projects %>
+  </tbody>
+</table>

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -2,19 +2,21 @@
   <h1>Projects</h1>
 </header>
 
-<table class="table table-striped table-hover projects">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Name</th>
-      <th scope="col">Tickets</th>
-      <th scope="col">New Tickets</th>
-      <th scope="col">Closed Tickets</th>
-      <th scope="col">Active Tickets</th>
-      <th scope="col">Action</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= render @projects %>
-  </tbody>
-</table>
+<div class="table-responsive">
+  <table class="table table-striped table-hover projects">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Name</th>
+        <th scope="col">Tickets</th>
+        <th scope="col">New Tickets</th>
+        <th scope="col">Closed Tickets</th>
+        <th scope="col">Active Tickets</th>
+        <th scope="col" colspan="2">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render @projects %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root 'application#index'
 
-    resources :projects, except: %i[index show]
+    resources :projects, except: %i[show]
     resources :users do
       member do
         patch :archive

--- a/spec/features/admin/managing_projects_spec.rb
+++ b/spec/features/admin/managing_projects_spec.rb
@@ -18,16 +18,15 @@ RSpec.feature 'Admins can manage projects' do
       project: vscode,
       state: FactoryBot.create(:state, name: 'Closed')
     )
-    
+
     login_as(FactoryBot.create(:user, :admin))
     visit admin_root_path
-  end
-
-  scenario 'and view them with their details' do
     within(find('ul>li', text: 'Projects')) do
       click_link 'Projects'
     end
+  end
 
+  scenario 'and view them with their details' do
     within 'table.projects' do
       expect(page).to have_link 'VS Code'
       expect(page).to have_content '0 new'
@@ -36,5 +35,15 @@ RSpec.feature 'Admins can manage projects' do
     end
 
     expect(page).to have_current_path(admin_projects_path)
+  end
+
+  scenario 'and delete any project' do
+    within(find('tr', text: 'Sublime')) do
+      click_link 'X'
+    end
+
+    expect(page).to have_content 'Project has been deleted.'
+    expect(page).to_not have_link 'Sublime'
+    expect(page).to have_link 'VS Code'
   end
 end

--- a/spec/features/admin/managing_projects_spec.rb
+++ b/spec/features/admin/managing_projects_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Admins can manage projects' do
+  let!(:vscode) { FactoryBot.create(:project, name: 'VS Code') }
+  let!(:sublime) { FactoryBot.create(:project, name: 'Sublime') }
+
+  before do
+    FactoryBot.create(
+      :ticket,
+      name: 'simple menu fix',
+      project: vscode,
+      state: FactoryBot.create(:state, name: 'Open')
+    )
+
+    FactoryBot.create(
+      :ticket,
+      name: 'simple menu fix',
+      project: vscode,
+      state: FactoryBot.create(:state, name: 'Closed')
+    )
+    
+    login_as(FactoryBot.create(:user, :admin))
+    visit admin_root_path
+  end
+
+  scenario 'and view them with their details' do
+    within(find('ul>li', text: 'Projects')) do
+      click_link 'Projects'
+    end
+
+    within 'table.projects' do
+      expect(page).to have_link 'VS Code'
+      expect(page).to have_content '0 new'
+      expect(page).to have_content '1 active'
+      expect(page).to have_content '1 closed'
+    end
+
+    expect(page).to have_current_path(admin_projects_path)
+  end
+end


### PR DESCRIPTION
## What does this PR do❓ 
This PR implemented the following features 👇 

- [x] Admins can view a list of all projects
- [x] Admins can delete a project from the `/admins/projects` page ❌
- [x] Added an edit link that leads to the `/admins/projects/:id/edit` page ✏️ 

## Description of the tasks completed 👇 
 
- [x] Used BDD - wrote failing tests before making them pass ✔️ 